### PR TITLE
Make the crate empty on non-windows targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,9 @@
 //!}
 //!```
 //!
+
+#![cfg(windows)]
+
 #[cfg(feature = "chrono")]
 extern crate chrono;
 #[cfg(feature = "serialization-serde")]


### PR DESCRIPTION
This makes it easier to use as a target-specific bulid-dependency. On any non-windows targets, the crate will simply become an empty crate, instead of causing compilation errors.